### PR TITLE
Correct MaxMem and CPUs for SLATE_US_UUTAH_NOTCHPEAK

### DIFF
--- a/10-noncms-osg.xml
+++ b/10-noncms-osg.xml
@@ -7462,8 +7462,8 @@
          <attrs>
             <attr name="GLEXEC_BIN" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="NONE"/>
             <attr name="GLIDEIN_Country" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="US"/>
-            <attr name="GLIDEIN_CPUS" const="True" glidein_publish="False" job_publish="True" parameter="True" publish="True" type="string" value="16"/>
-            <attr name="GLIDEIN_MaxMemMBs" const="True" glidein_publish="False" job_publish="True" parameter="True" publish="True" type="int" value="49152"/>
+            <attr name="GLIDEIN_CPUS" const="True" glidein_publish="False" job_publish="True" parameter="True" publish="True" type="string" value="8"/>
+            <attr name="GLIDEIN_MaxMemMBs" const="True" glidein_publish="False" job_publish="True" parameter="True" publish="True" type="int" value="16384"/>
             <attr name="GLIDEIN_Max_Walltime" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="int" value="84600"/>
             <attr name="GLIDEIN_REQUIRED_OS" const="True" glidein_publish="True" job_publish="False" parameter="True" publish="True" type="string" value="rhel7"/>
             <attr name="GLIDEIN_ResourceName" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="SLATE_US_UUTAH_NOTCHPEAK"/>


### PR DESCRIPTION
I've configured this to now match the correct limits for the cluster and the limits being set by the CE JOB_ROUTER_ENTRIES:

```
  JOB_ROUTER_ENTRIES @=jre
  [
    GridResource = "batch slurm osgusern@notchpeak1.chpc.utah.edu";
    Requirements = (Owner == "osgusern");
    set_default_queue = "notchpeak-osg";
    # 16 GB
    set_default_maxMemory = 16384;
    # 72 hours
    set_BatchRuntime = 4320;
    # 8 core jobs 
    set_default_xcount = 8;
  ]
  @jre
```