### PR TITLE
Rolling back an incomplete yml file in OSG_autoconf directory

### DIFF
--- a/OSG_autoconf/20-hosted-ces-itb.auto.yml
+++ b/OSG_autoconf/20-hosted-ces-itb.auto.yml
@@ -1,3 +1,0 @@
-UCSDT2:
-  osg-gw-6.t2.ucsd.edu:
-    CMSHTPC_T2_US_UCSD_gw6_fake:


### PR DESCRIPTION
The format of `20-hosted-ces-itb.auto.yml` is not intact, resulting a failure to be parsed correctly by the factory entry audit script `compare-factory-config.py` in opensciencegrid/topology/bin. 