### PR TITLE
osg-itb-ce1 should be used for GLOW ITB pilots

### DIFF
--- a/20-local-itb.xml
+++ b/20-local-itb.xml
@@ -3521,7 +3521,7 @@
             <attr name="GLIDEIN_REQUIRED_OS" const="True" glidein_publish="True" job_publish="False" parameter="True" publish="True" type="string" value="rhel7"/>
             <attr name="GLIDEIN_ResourceName" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="OSG-ITB-CE1"/>
             <attr name="GLIDEIN_Site" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="OSG-ITB-CE1"/>
-            <attr name="GLIDEIN_Supported_VOs" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="OSGVO"/>
+            <attr name="GLIDEIN_Supported_VOs" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="GLOWITB"/>
          </attrs>
          <files>
          </files>


### PR DESCRIPTION
Note @bbockelm this will mean GLOW ITB pilots are submitted to the CHTC pool since that's where `osg-itb-ce1.osg.chtc.io` is submitting