### PR TITLE
Fix invalid YAML

### DIFF
--- a/OSG_autoconf/20-hosted-ces-itb.auto.yml
+++ b/OSG_autoconf/20-hosted-ces-itb.auto.yml
@@ -1,6 +1,6 @@
 UCSDT2:
   osg-gw-6.t2.ucsd.edu:
-    CMSHTPC_T2_US_UCSD_gw6_fake:
+    CMSHTPC_T2_US_UCSD_gw6_fake: []
 
 Stampede2:
   hosted-ce10.opensciencegrid.org:


### PR DESCRIPTION
Causes PyYAML 4.2b4 to throw a `YAMLError`