### PR TITLE
Turn the entry for the hosted CE OSG_CHTC-Canary2 into an OSG_autoconf entry

### DIFF
--- a/10-noncms-osg.xml
+++ b/10-noncms-osg.xml
@@ -2535,44 +2535,6 @@
          <monitorgroups>
          </monitorgroups>
       </entry>
-      <entry name="OSG_CHTC-canary2" auth_method="grid_proxy" comment="Add entry 2021-05-25 --Edita" enabled="True" gatekeeper="canary2.osg.chtc.io canary2.osg.chtc.io:9619" gridtype="condor" trust_domain="grid" verbosity="std" work_dir="OSG">
-         <config>
-            <max_jobs>
-               <default_per_frontend glideins="10" held="10" idle="10"/>
-               <per_entry glideins="20" held="20" idle="20"/>
-               <per_frontends>
-               </per_frontends>
-            </max_jobs>
-            <release max_per_cycle="20" sleep="0.2"/>
-            <remove max_per_cycle="5" sleep="0.2"/>
-            <restrictions require_glidein_glexec_use="False" require_voms_proxy="False"/>
-            <submit cluster_size="1" max_per_cycle="20" sleep="0.2" slots_layout="fixed">
-               <submit_attrs>
-                  <submit_attr name="+maxMemory" value="128000"/>
-                  <submit_attr name="+maxWallTime" value="1440"/>
-                  <submit_attr name="+xcount" value="20"/>
-               </submit_attrs>
-            </submit>
-         </config>
-         <allow_frontends>
-         </allow_frontends>
-         <attrs>
-            <attr name="GLEXEC_BIN" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="NONE"/>
-            <attr name="GLIDEIN_CPUS" const="True" glidein_publish="False" job_publish="True" parameter="True" publish="True" type="string" value="20"/>
-            <attr name="GLIDEIN_MaxMemMBs" const="True" glidein_publish="True" job_publish="False" parameter="True" publish="True" type="int" value="128000"/>
-            <attr name="GLIDEIN_Max_Walltime" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="int" value="84600"/>
-            <attr name="GLIDEIN_REQUIRED_OS" const="True" glidein_publish="True" job_publish="False" parameter="True" publish="True" type="string" value="any"/>
-            <attr name="GLIDEIN_ResourceName" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="CHTC"/>
-            <attr name="GLIDEIN_Site" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="CHTC-canary2"/>
-            <attr name="GLIDEIN_Supported_VOs" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="OSGVO,GLOW"/>
-         </attrs>
-         <files>
-         </files>
-         <infosys_refs>
-         </infosys_refs>
-         <monitorgroups>
-         </monitorgroups>
-      </entry>
       <entry name="OSG_US_BEOCAT-SLATE_slate-osg" auth_method="grid_proxy" comment="Added entry 2021-02-11 --Edita" enabled="True" gatekeeper="slate-osg.beocat.ksu.edu slate-osg.beocat.ksu.edu:9619" gridtype="condor" trust_domain="grid" verbosity="std" work_dir="OSG">
          <config>
             <max_jobs>

--- a/OSG_autoconf/10-hosted-ces.auto.yml
+++ b/OSG_autoconf/10-hosted-ces.auto.yml
@@ -175,6 +175,19 @@ CHTC:
             glideins: 10
         work_dir: Condor
 
+  canary2.osg.chtc.io:
+    BEST_FIT:
+      OSG_CHTC-canary2:
+        limits:
+          entry:
+            glideins: 20
+            idle: 20
+            held: 20
+        attrs:
+          GLIDEIN_Supported_VOs:
+            # value: "OSGVO,GLOW"
+            value: "OSGVO"
+
 OSG_DELL_M420_ASU:
   hosted-ce20.opensciencegrid.org:
     BEST_FIT:

--- a/OSG_autoconf/10-hosted-ces.auto.yml
+++ b/OSG_autoconf/10-hosted-ces.auto.yml
@@ -180,13 +180,15 @@ CHTC:
       OSG_CHTC-canary2:
         limits:
           entry:
-            glideins: 20
-            idle: 20
-            held: 20
+            glideins: 8
+            idle: 25
+            held: 25
         attrs:
           GLIDEIN_Supported_VOs:
             # value: "OSGVO,GLOW"
             value: "OSGVO"
+          GLIDEIN_ResourceName:
+            value: "CHTC-canary2"
 
 OSG_DELL_M420_ASU:
   hosted-ce20.opensciencegrid.org:


### PR DESCRIPTION
This CE uses the hosted CE chart; memory, walltime, etc. should be provided by the OSG_ResourceCatalog.
