### PR TITLE
CMS_T2_US_Nebraska_Red_test_apptainer Singularity tweaks

### DIFF
--- a/10-cmst1-uscmst2-all.xml
+++ b/10-cmst1-uscmst2-all.xml
@@ -6247,7 +6247,7 @@
             <attr name="GLIDEIN_ResourceName" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="Nebraska"/>
             <attr name="GLIDEIN_SE_VONAME_LOWERCASE" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="srm://srm.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/"/>
             <attr name="GLIDEIN_SEs" comment="CMS Requires srm.unl.edu. don't change" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="srm.unl.edu"/>
-            <attr name="GLIDEIN_SINGULARITY_BINARY_OVERRIDE" const="True" glidein_publish="True" job_publish="False" parameter="True" publish="True" type="string" value="/cvmfs/oasis.opensciencegrid.org/mis/apptainer/testing/bin/apptainer"/>
+            <attr name="GLIDEIN_SINGULARITY_BINARY_OVERRIDE" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="/cvmfs/oasis.opensciencegrid.org/mis/apptainer/testing/bin/apptainer"/>
             <attr name="GLIDEIN_Site" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="Nebraska"/>
             <attr name="GLIDEIN_Supported_VOs" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="CMS,CMST2UCSD,OSGVO"/>
             <attr name="UPDATE_COLLECTOR_WITH_TCP" comment="Trying UDP to get around NAT issues, see 'Improving debug of glideIn failures' email 2014-03-12 --Jeff" const="False" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="False"/>


### PR DESCRIPTION
I'm not seeing the testing apptainer binary in use at Nebraska:
```
INFO  Sourcing add config line: /var/lib/condor/execute/dir_1181163/glide_RkqYDr/add_config_line.source
INFO  Checking for singularity...
INFO  Singularity at '/cvmfs/oasis.opensciencegrid.org/mis/singularity/bin/singularity' appears to work (unprivileged mode)
```

The [factory docs](https://glideinwms.fnal.gov/doc.prd/factory/custom_vars.html#singularity_vars) mention that for `GLIDEIN_SINGULARITY_BINARY_OVERRIDE`, ` job_publish` must be set true.