### PR TITLE
Scaling step MTState-Tempest 50x(8c+30GB); FD #74884

### DIFF
--- a/OSG_autoconf/10-hosted-ces.auto.yml
+++ b/OSG_autoconf/10-hosted-ces.auto.yml
@@ -711,14 +711,25 @@ MTState-Tempest:
         num_factories: 2
         limits:
           entry:
-            glideins: 2
+            glideins: 50
+        submit_attrs:
+          +queue: '&quot;osg-epyc&quot;'
+          +xcount: 8
+          +maxMemory: 30720
+          +maxWallTime: 4320
         attrs:
           GLIDEIN_ResourceName:
             value: MTState-Tempest-CE1
           GLIDEIN_Country:
             value: US
-        submit_attrs:
-          +queue: '&quot;osg-epyc&quot;'
+          GLIDEIN_Supported_VOs:
+            value: OSGVO
+          GLIDEIN_CPUS:
+            value: 8
+          GLIDEIN_MaxMemMBs:
+            value: 30720
+          GLIDEIN_Max_Walltime:
+            value: 259200
 
 ND_CAMLGPU:
   nd-caml-gpu-ce1.svc.opensciencegrid.org:

--- a/OSG_autoconf/10-hosted-ces.auto.yml
+++ b/OSG_autoconf/10-hosted-ces.auto.yml
@@ -725,7 +725,7 @@ MTState-Tempest:
           GLIDEIN_Supported_VOs:
             value: OSGVO
           GLIDEIN_CPUS:
-            value: 8
+            value: 16
           GLIDEIN_MaxMemMBs:
             value: 30720
           GLIDEIN_Max_Walltime:


### PR DESCRIPTION
This was the line in Coltran’s email:

osg-epyc              8             30GB                    16GB                    3 days                  992

And then he asked for a step up to 50 glideins max.

I think there is a separate step — somewhere else — to set the Slurm disk request to match whatever HTCondor calculates.