### PR TITLE
Decrease glideins going to OSG_US_CHTC-Spark-CE1_pre to 2

### DIFF
--- a/OSG_autoconf/10-hosted-ces.auto.yml
+++ b/OSG_autoconf/10-hosted-ces.auto.yml
@@ -257,7 +257,7 @@ CHTC-Spark:
         num_factories: 2
         limits:
           entry:
-            glideins: 200
+            glideins: 2
         attrs:
           GLIDEIN_ResourceName:
             value: CHTC-Spark-CE1


### PR DESCRIPTION
I'm using OSG_CHTC-canary2 for experimentation and would like glideins going to the "pre" queue to go through there instead.

Cc. @brianhlin 