### PR TITLE
Laf/Swat Firebird: Lowered glidein cap for net bandwith; FD #78353

### DIFF
--- a/OSG_autoconf/10-hosted-ces.auto.yml
+++ b/OSG_autoconf/10-hosted-ces.auto.yml
@@ -1848,7 +1848,7 @@ Lafayette-Firebird:
         num_factories: 1
         limits:
           entry:
-            glideins: 60
+            glideins: 20
         attrs:
           GLIDEIN_CPUS:
             value: 4
@@ -1870,7 +1870,7 @@ Swarthmore-Firebird:
         num_factories: 1
         limits:
           entry:
-            glideins: 60
+            glideins: 20
         attrs:
           GLIDEIN_CPUS:
             value: 4


### PR DESCRIPTION
Request not in ticket (yet) — all in Slack. Lafayette networking folks are concerned about new network I/O to WAN, Peter asked us to scale back. No need to remove existing glideins (yet).