### PR TITLE
Attempt to fix EL10 25.x glidein startup

### DIFF
--- a/10-noncms-osg.xml
+++ b/10-noncms-osg.xml
@@ -4016,6 +4016,7 @@
          <allow_frontends>
          </allow_frontends>
          <attrs>
+            <attr name="CONDOR_ARCH" const="False" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="auto"/>
             <attr name="GLEXEC_BIN" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="NONE"/>
             <attr name="GLIDEIN_CPUS" const="True" glidein_publish="False" job_publish="True" parameter="True" publish="True" type="string" value="8"/>
             <attr name="GLIDEIN_Country" const="True" glidein_publish="True" job_publish="False" parameter="True" publish="True" type="string" value="US"/>
@@ -4098,6 +4099,7 @@
          <allow_frontends>
          </allow_frontends>
          <attrs>
+            <attr name="CONDOR_ARCH" const="False" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="auto"/>
             <attr name="GLEXEC_BIN" const="True" glidein_publish="False" job_publish="False" parameter="True" publish="True" type="string" value="NONE"/>
             <attr name="GLIDEIN_CPUS" const="True" glidein_publish="False" job_publish="True" parameter="True" publish="True" type="string" value="8"/>
             <attr name="GLIDEIN_Country" const="True" glidein_publish="True" job_publish="False" parameter="True" publish="True" type="string" value="US"/>


### PR DESCRIPTION
It's getting set to 'default' and I'm guessing that neither of these are in the platform list:

- `CONDOR_PLATFORM_25.x_linux-rhel10-default`
- `CONDOR_PLATFORM_25.x_rhel10-default`